### PR TITLE
GTFS Validator Diff JSON Schema

### DIFF
--- a/examples/example_1/gtfs_validator_diff.json
+++ b/examples/example_1/gtfs_validator_diff.json
@@ -1,0 +1,119 @@
+{
+	"summary": {
+        "metadata": {
+            "validator_version": {
+                "old_validator_version": "7.0",
+                "new_validator_version": "7.1"
+            },
+            "service_window": {
+                "old_service_window": {
+                    "start_date": "20240101",
+                    "end_date": "20241231"
+                },
+                "new_service_window": {
+                    "start_date": "20250101",
+                    "end_date": "20251231"
+                }
+            },
+            "counts": {
+                "agencies": {
+                    "diff": 0,
+                    "old_count": 1,
+                    "new_count": 1
+                },
+                "blocks": {
+                    "diff": 0,
+                    "old_count": 5,
+                    "new_count": 5
+                },
+                "routes": {
+                    "diff": 0,
+                    "old_count": 10,
+                    "new_count": 10
+                },
+                "shapes": {
+                    "diff": 1,
+                    "old_count": 8,
+                    "new_count": 9
+                },
+                "stops": {
+                    "diff": 0,
+                    "old_count": 150,
+                    "new_count": 150
+                },
+                "trips": {
+                    "diff": -20,
+                    "old_count": 200,
+                    "new_count": 190
+                }
+            },
+            "features": {
+                "added": ["fares"],
+                "removed": ["location types"]
+            }
+        },
+        "compliance": {
+            "totalNotices": {
+                "diff": -100,
+                "old_count": 200,
+                "new_count": 100
+            },
+            "uniqueNotices": {
+                "diff": -9,
+                "old_count": 10,
+                "new_count": 1
+            },
+            "uniqueErrorNotices": {
+                "diff": -2,
+                "old_count": 3,
+                "new_count": 1
+            },
+            "uniqueWarningNotices": {
+                "diff": -1,
+                "old_count": 1,
+                "new_count": 0
+            },
+            "uniqueInfoNotices": {
+                "diff": 0,
+                "old_count": 0,
+                "new_count": 0
+            }
+        }
+    },
+    "notices": [
+        {
+            "code": "decreasing_or_equal_stop_time_distance",
+            "severity": "ERROR",
+            "totalNotices": 1,
+            "sampleNotices":[
+                {
+                    "tripId": "71436504",
+                    "stopId": "8321",
+                    "csvRowNumber": 576301,
+                    "shapeDistTraveled": 3.365,
+                    "stopSequence": 13,
+                    "prevCsvRowNumber": 576300,
+                    "prevShapeDistTraveled": 3.365,
+                    "prevStopSequence": 12
+                }
+            ]
+        },
+        {
+            "code": "missing_recommended_field",
+            "severity": "WARNING",
+            "totalNotices": 2,
+            "sampleNotices": [
+                {
+                    "filename": "agency.txt",
+                    "csvRowNumber": 2,
+                    "fieldName": "agency_id"
+                },
+                {
+                    "filename": "routes.txt",
+                    "csvRowNumber": 2,
+                    "fieldName": "agency_id"
+                }
+            ]
+        }
+    ]
+}

--- a/examples/example_1/gtfs_validator_diff.json
+++ b/examples/example_1/gtfs_validator_diff.json
@@ -1,0 +1,99 @@
+{
+	"summary": {
+        "metadata": {
+            "validator_version": {
+                "old_validator_version": "7.0",
+                "new_validator_version": "7.1"
+            },
+            "service_window": {
+                "old_service_window": {
+                    "start_date": "20240101",
+                    "end_date": "20241231"
+                },
+                "new_service_window": {
+                    "start_date": "20250101",
+                    "end_date": "20251231"
+                }
+            },
+            "counts": {
+                "agencies": {
+                    "diff": 0,
+                    "old_count": 1,
+                    "new_count": 1
+                },
+                "blocks": {
+                    "diff": 0,
+                    "old_count": 5,
+                    "new_count": 5
+                },
+                "routes": {
+                    "diff": 0,
+                    "old_count": 10,
+                    "new_count": 10
+                },
+                "shapes": {
+                    "diff": 1,
+                    "old_count": 8,
+                    "new_count": 9
+                },
+                "stops": {
+                    "diff": 0,
+                    "old_count": 150,
+                    "new_count": 150
+                },
+                "trips": {
+                    "diff": -20,
+                    "old_count": 200,
+                    "new_count": 190
+                }
+            },
+            "features": {
+                "added": ["fares"],
+                "removed": []
+            }
+        },
+        "compliance": {
+            "totalNotices": 3,
+            "uniqueNotices": 2,
+            "uniqueErrorNotices": 1,
+            "uniqueWarningNotices": 1,
+            "uniqueInfoNotices": 0
+        }
+    },
+    "notices": [
+        {
+            "code": "decreasing_or_equal_stop_time_distance",
+            "severity": "ERROR",
+            "totalNotices": 1,
+            "sampleNotices":[
+                {
+                    "tripId": "71436504",
+                    "stopId": "8321",
+                    "csvRowNumber": 576301,
+                    "shapeDistTraveled": 3.365,
+                    "stopSequence": 13,
+                    "prevCsvRowNumber": 576300,
+                    "prevShapeDistTraveled": 3.365,
+                    "prevStopSequence": 12
+                }
+            ]
+        },
+        {
+            "code": "missing_recommended_field",
+            "severity": "WARNING",
+            "totalNotices": 2,
+            "sampleNotices": [
+                {
+                    "filename": "agency.txt",
+                    "csvRowNumber": 2,
+                    "fieldName": "agency_id"
+                },
+                {
+                    "filename": "routes.txt",
+                    "csvRowNumber": 2,
+                    "fieldName": "agency_id"
+                }
+            ]
+        }
+    ]
+}

--- a/json_schema/gtfs_validator_diff_schema.json
+++ b/json_schema/gtfs_validator_diff_schema.json
@@ -1,0 +1,368 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "summary": {
+      "type": "object",
+      "properties": {
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "validator_version": {
+              "type": "object",
+              "properties": {
+                "old_validator_version": {
+                  "type": "string"
+                },
+                "new_validator_version": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "old_validator_version",
+                "new_validator_version"
+              ]
+            },
+            "service_window": {
+              "type": "object",
+              "properties": {
+                "old_service_window": {
+                  "type": "object",
+                  "properties": {
+                    "start_date": {
+                      "type": "string"
+                    },
+                    "end_date": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "start_date",
+                    "end_date"
+                  ]
+                },
+                "new_service_window": {
+                  "type": "object",
+                  "properties": {
+                    "start_date": {
+                      "type": "string"
+                    },
+                    "end_date": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "start_date",
+                    "end_date"
+                  ]
+                }
+              },
+              "required": [
+                "old_service_window",
+                "new_service_window"
+              ]
+            },
+            "counts": {
+              "type": "object",
+              "properties": {
+                "agencies": {
+                  "type": "object",
+                  "properties": {
+                    "diff": {
+                      "type": "number"
+                    },
+                    "old_count": {
+                      "type": "number"
+                    },
+                    "new_count": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "diff",
+                    "old_count",
+                    "new_count"
+                  ]
+                },
+                "blocks": {
+                  "type": "object",
+                  "properties": {
+                    "diff": {
+                      "type": "number"
+                    },
+                    "old_count": {
+                      "type": "number"
+                    },
+                    "new_count": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "diff",
+                    "old_count",
+                    "new_count"
+                  ]
+                },
+                "routes": {
+                  "type": "object",
+                  "properties": {
+                    "diff": {
+                      "type": "number"
+                    },
+                    "old_count": {
+                      "type": "number"
+                    },
+                    "new_count": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "diff",
+                    "old_count",
+                    "new_count"
+                  ]
+                },
+                "shapes": {
+                  "type": "object",
+                  "properties": {
+                    "diff": {
+                      "type": "number"
+                    },
+                    "old_count": {
+                      "type": "number"
+                    },
+                    "new_count": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "diff",
+                    "old_count",
+                    "new_count"
+                  ]
+                },
+                "stops": {
+                  "type": "object",
+                  "properties": {
+                    "diff": {
+                      "type": "number"
+                    },
+                    "old_count": {
+                      "type": "number"
+                    },
+                    "new_count": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "diff",
+                    "old_count",
+                    "new_count"
+                  ]
+                },
+                "trips": {
+                  "type": "object",
+                  "properties": {
+                    "diff": {
+                      "type": "number"
+                    },
+                    "old_count": {
+                      "type": "number"
+                    },
+                    "new_count": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "diff",
+                    "old_count",
+                    "new_count"
+                  ]
+                }
+              },
+              "required": [
+                "agencies",
+                "blocks",
+                "routes",
+                "shapes",
+                "stops",
+                "trips"
+              ]
+            },
+            "features": {
+              "type": "object",
+              "properties": {
+                "added": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "removed": {
+                  "type": "array",
+                  "items": {}
+                }
+              },
+              "required": [
+                "added",
+                "removed"
+              ]
+            }
+          },
+          "required": [
+            "validator_version",
+            "service_window",
+            "counts",
+            "features"
+          ]
+        },
+        "compliance": {
+          "type": "object",
+          "properties": {
+            "totalNotices": {
+              "type": "object",
+              "properties": {
+                "diff": {
+                  "type": "number"
+                },
+                "old_count": {
+                  "type": "number"
+                },
+                "new_count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "diff",
+                "old_count",
+                "new_count"
+              ]
+            },
+            "uniqueNotices": {
+              "type": "object",
+              "properties": {
+                "diff": {
+                  "type": "number"
+                },
+                "old_count": {
+                  "type": "number"
+                },
+                "new_count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "diff",
+                "old_count",
+                "new_count"
+              ]
+            },
+            "uniqueErrorNotices": {
+              "type": "object",
+              "properties": {
+                "diff": {
+                  "type": "number"
+                },
+                "old_count": {
+                  "type": "number"
+                },
+                "new_count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "diff",
+                "old_count",
+                "new_count"
+              ]
+            },
+            "uniqueWarningNotices": {
+              "type": "object",
+              "properties": {
+                "diff": {
+                  "type": "number"
+                },
+                "old_count": {
+                  "type": "number"
+                },
+                "new_count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "diff",
+                "old_count",
+                "new_count"
+              ]
+            },
+            "uniqueInfoNotices": {
+              "type": "object",
+              "properties": {
+                "diff": {
+                  "type": "number"
+                },
+                "old_count": {
+                  "type": "number"
+                },
+                "new_count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "diff",
+                "old_count",
+                "new_count"
+              ]
+            }
+          },
+          "required": [
+            "totalNotices",
+            "uniqueNotices",
+            "uniqueErrorNotices",
+            "uniqueWarningNotices",
+            "uniqueInfoNotices"
+          ]
+        }
+      },
+      "required": [
+        "metadata",
+        "compliance"
+      ]
+    },
+    "notices": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          },
+          "totalNotices": {
+            "type": "number"
+          },
+          "sampleNotices": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "type": ["string", "number"]
+              }
+            }
+          }
+        },
+        "required": [
+          "code",
+          "severity",
+          "totalNotices",
+          "sampleNotices"
+        ]
+      }
+    }
+  },
+  "required": [
+    "summary"
+  ]
+}

--- a/json_schema/gtfs_validator_diff_schema.json
+++ b/json_schema/gtfs_validator_diff_schema.json
@@ -1,0 +1,288 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "summary": {
+      "type": "object",
+      "properties": {
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "validator_version": {
+              "type": "object",
+              "properties": {
+                "old_validator_version": {
+                  "type": "string"
+                },
+                "new_validator_version": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "old_validator_version",
+                "new_validator_version"
+              ]
+            },
+            "service_window": {
+              "type": "object",
+              "properties": {
+                "old_service_window": {
+                  "type": "object",
+                  "properties": {
+                    "start_date": {
+                      "type": "string"
+                    },
+                    "end_date": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "start_date",
+                    "end_date"
+                  ]
+                },
+                "new_service_window": {
+                  "type": "object",
+                  "properties": {
+                    "start_date": {
+                      "type": "string"
+                    },
+                    "end_date": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "start_date",
+                    "end_date"
+                  ]
+                }
+              },
+              "required": [
+                "old_service_window",
+                "new_service_window"
+              ]
+            },
+            "counts": {
+              "type": "object",
+              "properties": {
+                "agencies": {
+                  "type": "object",
+                  "properties": {
+                    "diff": {
+                      "type": "number"
+                    },
+                    "old_count": {
+                      "type": "number"
+                    },
+                    "new_count": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "diff",
+                    "old_count",
+                    "new_count"
+                  ]
+                },
+                "blocks": {
+                  "type": "object",
+                  "properties": {
+                    "diff": {
+                      "type": "number"
+                    },
+                    "old_count": {
+                      "type": "number"
+                    },
+                    "new_count": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "diff",
+                    "old_count",
+                    "new_count"
+                  ]
+                },
+                "routes": {
+                  "type": "object",
+                  "properties": {
+                    "diff": {
+                      "type": "number"
+                    },
+                    "old_count": {
+                      "type": "number"
+                    },
+                    "new_count": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "diff",
+                    "old_count",
+                    "new_count"
+                  ]
+                },
+                "shapes": {
+                  "type": "object",
+                  "properties": {
+                    "diff": {
+                      "type": "number"
+                    },
+                    "old_count": {
+                      "type": "number"
+                    },
+                    "new_count": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "diff",
+                    "old_count",
+                    "new_count"
+                  ]
+                },
+                "stops": {
+                  "type": "object",
+                  "properties": {
+                    "diff": {
+                      "type": "number"
+                    },
+                    "old_count": {
+                      "type": "number"
+                    },
+                    "new_count": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "diff",
+                    "old_count",
+                    "new_count"
+                  ]
+                },
+                "trips": {
+                  "type": "object",
+                  "properties": {
+                    "diff": {
+                      "type": "number"
+                    },
+                    "old_count": {
+                      "type": "number"
+                    },
+                    "new_count": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "diff",
+                    "old_count",
+                    "new_count"
+                  ]
+                }
+              },
+              "required": [
+                "agencies",
+                "blocks",
+                "routes",
+                "shapes",
+                "stops",
+                "trips"
+              ]
+            },
+            "features": {
+              "type": "object",
+              "properties": {
+                "added": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "removed": {
+                  "type": "array",
+                  "items": {}
+                }
+              },
+              "required": [
+                "added",
+                "removed"
+              ]
+            }
+          },
+          "required": [
+            "validator_version",
+            "service_window",
+            "counts",
+            "features"
+          ]
+        },
+        "compliance": {
+          "type": "object",
+          "properties": {
+            "totalNotices": {
+              "type": "number"
+            },
+            "uniqueNotices": {
+              "type": "number"
+            },
+            "uniqueErrorNotices": {
+              "type": "number"
+            },
+            "uniqueWarningNotices": {
+              "type": "number"
+            },
+            "uniqueInfoNotices": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "totalNotices",
+            "uniqueNotices",
+            "uniqueErrorNotices",
+            "uniqueWarningNotices",
+            "uniqueInfoNotices"
+          ]
+        }
+      },
+      "required": [
+        "metadata",
+        "compliance"
+      ]
+    },
+    "notices": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          },
+          "totalNotices": {
+            "type": "number"
+          },
+          "sampleNotices": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "type": ["string", "number"]
+              }
+            }
+          }
+        },
+        "required": [
+          "code",
+          "severity",
+          "totalNotices",
+          "sampleNotices"
+        ]
+      }
+    }
+  },
+  "required": [
+    "summary"
+  ]
+}


### PR DESCRIPTION
Not to necessarily merge, but to continue the discussion on the JSON schema for GTFS validation report diffs. Follows JSON schema version 2020-12. Although I don't think we will actually need a formally defined schema, it conveys an idea of the JSON structure (or somewhere to start). 

Rough structure, where some of the "diff" types are described below:

```json
{
	"summary": {
        "metadata": {
            "validator_version": "diff",
            "service_window":  "diff",
            "counts": {
                "agencies": "diff",
                "blocks": "diff",
                "routes": "diff",
                "shapes": "diff",
                "stops": "diff",
                "trips": "diff"
            },
            "features": "diff"
        },
        "compliance": {
            "totalNotices": "diff",
            "uniqueNotices": "diff",
            "uniqueErrorNotices": "diff",
            "uniqueWarningNotices": "diff",
            "uniqueInfoNotices": "diff"
        }
    },
    "notices": "same format as validator notices"
}
```

Diff types:
- Added/removed (strings)

```json
"features": {
    "added": ["fares"],
    "removed": []
}
```

- Count (integer)

```json
"counts": {
    "trips": {
        "diff": -20,
        "old_count": 200,
        "new_count": 190
    }
}
```
``` json
"compliance": {
    "totalNotices": {
        "diff": -100,
        "old_count": 200,
        "new_count": 100
    }
}
```

- Old/new (strings)

``` json
"service_window": {
    "old_service_window": {
        "start_date": "20240101",
        "end_date": "20241231"
    },
    "new_service_window": {
        "start_date": "20250101",
        "end_date": "20251231"
    }
}
```
``` json
"validator_version": {
    "old_validator_version": "7.0",
    "new_validator_version": "7.1"
}
```
