### PR TITLE
GTFS Diff schema v2-rc1 update

### DIFF
--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -1,0 +1,28 @@
+name: Validate JSON Schema
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "spec/**/*.json"
+  pull_request:
+    paths:
+      - "spec/**/*.json"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install jsonschema
+
+      - name: Validate JSON syntax
+        run: ./scripts/validate_json_syntax.sh
+
+      - name: Validate examples against schema
+        run: ./scripts/validate_examples.sh

--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -5,9 +5,13 @@ on:
     branches: [main]
     paths:
       - "spec/**/*.json"
+      - "scripts/validate_examples.sh"
+      - "scripts/validate_json_syntax.sh"
   pull_request:
     paths:
       - "spec/**/*.json"
+      - "scripts/validate_examples.sh"
+      - "scripts/validate_json_syntax.sh"
 
 jobs:
   validate:

--- a/scripts/validate_examples.sh
+++ b/scripts/validate_examples.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exit_code=0
+for schema_dir in spec/*/json_schema; do
+  version_dir=$(dirname "$schema_dir")
+  examples_dir="$version_dir/examples"
+  schema_file=$(find "$schema_dir" -name '*.json' | head -1)
+
+  if [ -z "$schema_file" ] || [ ! -d "$examples_dir" ]; then
+    continue
+  fi
+
+  echo "Schema: $schema_file"
+  for example in "$examples_dir"/*.json; do
+    echo "  Validating: $example"
+    if python3 -c "
+import json, jsonschema, sys
+with open('$schema_file') as f:
+    schema = json.load(f)
+with open('$example') as f:
+    instance = json.load(f)
+try:
+    jsonschema.validate(instance, schema)
+    print('    PASS')
+except jsonschema.ValidationError as e:
+    print(f'    FAIL: {e.message}')
+    sys.exit(1)
+"; then
+      :
+    else
+      exit_code=1
+    fi
+  done
+done
+exit $exit_code

--- a/scripts/validate_json_syntax.sh
+++ b/scripts/validate_json_syntax.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exit_code=0
+for f in $(find spec -name '*.json'); do
+  if ! python3 -m json.tool "$f" > /dev/null 2>&1; then
+    echo "FAIL: $f"
+    exit_code=1
+  else
+    echo "OK: $f"
+  fi
+done
+exit $exit_code

--- a/spec/v2/examples/example_output.json
+++ b/spec/v2/examples/example_output.json
@@ -40,6 +40,7 @@
         "stats": {
           "total_rows_base": 5000,
           "total_rows_new": 5075,
+          "total_rows_modified": 1048,
           "rows_changed_percentage": 23.9,
           "column_stats": [
             {
@@ -70,6 +71,7 @@
         "stats": {
           "total_rows_base": 50,
           "total_rows_new": 51,
+          "total_rows_modified": 5,
           "rows_changed_percentage": 15.7,
           "column_stats": [
             {
@@ -115,6 +117,7 @@
       "stats": {
         "total_rows_base": 5000,
         "total_rows_new": 5075,
+        "total_rows_modified": 1048,
         "rows_changed_percentage": 23.9,
         "column_stats": [
           {
@@ -170,6 +173,7 @@
       "stats": {
         "total_rows_base": 50,
         "total_rows_new": 51,
+        "total_rows_modified": 5,
         "rows_changed_percentage": 15.7,
         "column_stats": [
           {

--- a/spec/v2/examples/example_output.json
+++ b/spec/v2/examples/example_output.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "schema_version": "2.0.0",
+    "schema_version": "2.0.0-rc1",
     "generated_at": "2026-04-08T14:30:00Z",
     "row_changes_cap_per_file": 50,
     "base_feed": {
@@ -28,6 +28,7 @@
     "files_added_count": 1,
     "files_deleted_count": 0,
     "files_modified_count": 2,
+    "files_not_compared_count": 1,
     "files": [
       { "file_name": "shapes.txt", "status": "added", "rows_added_count": 30 },
       {
@@ -35,7 +36,29 @@
         "status": "modified",
         "rows_added_count": 120,
         "rows_deleted_count": 45,
-        "rows_modified_count": 1048
+        "rows_modified_count": 1048,
+        "stats": {
+          "total_rows_base": 5000,
+          "total_rows_new": 5075,
+          "rows_changed_percentage": 23.9,
+          "column_stats": [
+            {
+              "column": "arrival_time",
+              "modifications_count": 800,
+              "modifications_percentage": 76.3
+            },
+            {
+              "column": "departure_time",
+              "modifications_count": 790,
+              "modifications_percentage": 75.4
+            },
+            {
+              "column": "stop_id",
+              "modifications_count": 12,
+              "modifications_percentage": 1.1
+            }
+          ]
+        }
       },
       {
         "file_name": "stops.txt",
@@ -43,7 +66,28 @@
         "columns_deleted_count": 1,
         "rows_added_count": 2,
         "rows_deleted_count": 1,
-        "rows_modified_count": 5
+        "rows_modified_count": 5,
+        "stats": {
+          "total_rows_base": 50,
+          "total_rows_new": 51,
+          "rows_changed_percentage": 15.7,
+          "column_stats": [
+            {
+              "column": "stop_name",
+              "modifications_count": 3,
+              "modifications_percentage": 60.0
+            },
+            {
+              "column": "stop_lat",
+              "modifications_count": 2,
+              "modifications_percentage": 40.0
+            }
+          ]
+        }
+      },
+      {
+        "file_name": "trips.txt",
+        "status": "not_compared"
       }
     ]
   },
@@ -59,6 +103,37 @@
       "file_action": "modified",
       "columns_added": [],
       "columns_deleted": [],
+      "ignored_columns": [
+        {
+          "column": "trip_id",
+          "reason": {
+            "code": "id_churn",
+            "message": "Column references trips.txt which was not compared due to ID churn."
+          }
+        }
+      ],
+      "stats": {
+        "total_rows_base": 5000,
+        "total_rows_new": 5075,
+        "rows_changed_percentage": 23.9,
+        "column_stats": [
+          {
+            "column": "arrival_time",
+            "modifications_count": 800,
+            "modifications_percentage": 76.3
+          },
+          {
+            "column": "departure_time",
+            "modifications_count": 790,
+            "modifications_percentage": 75.4
+          },
+          {
+            "column": "stop_id",
+            "modifications_count": 12,
+            "modifications_percentage": 1.1
+          }
+        ]
+      },
       "row_changes": {
         "primary_key": ["trip_id", "stop_sequence"],
         "columns": ["trip_id", "arrival_time", "departure_time", "stop_id", "stop_sequence"],
@@ -92,6 +167,23 @@
       "file_action": "modified",
       "columns_added": [],
       "columns_deleted": [{ "name": "internal_id", "position": 6 }],
+      "stats": {
+        "total_rows_base": 50,
+        "total_rows_new": 51,
+        "rows_changed_percentage": 15.7,
+        "column_stats": [
+          {
+            "column": "stop_name",
+            "modifications_count": 3,
+            "modifications_percentage": 60.0
+          },
+          {
+            "column": "stop_lat",
+            "modifications_count": 2,
+            "modifications_percentage": 40.0
+          }
+        ]
+      },
       "row_changes": {
         "primary_key": ["stop_id"],
         "columns": ["stop_id", "stop_name", "stop_lat", "stop_lon", "zone_id"],
@@ -121,6 +213,14 @@
             ]
           }
         ]
+      }
+    },
+    {
+      "file_name": "trips.txt",
+      "file_action": "not_compared",
+      "not_compared_reason": {
+        "code": "id_churn",
+        "message": "Primary key values differ too much between versions to produce a meaningful diff (>90% of IDs changed)."
       }
     }
   ]

--- a/spec/v2/examples/example_output.json
+++ b/spec/v2/examples/example_output.json
@@ -30,63 +30,9 @@
     "files_modified_count": 2,
     "files_not_compared_count": 1,
     "files": [
-      { "file_name": "shapes.txt", "status": "added", "rows_added_count": 30 },
-      {
-        "file_name": "stop_times.txt",
-        "status": "modified",
-        "rows_added_count": 120,
-        "rows_deleted_count": 45,
-        "rows_modified_count": 1048,
-        "stats": {
-          "total_rows_base": 5000,
-          "total_rows_new": 5075,
-          "total_rows_modified": 1048,
-          "rows_changed_percentage": 23.9,
-          "column_stats": [
-            {
-              "column": "arrival_time",
-              "modifications_count": 800,
-              "modifications_percentage": 76.3
-            },
-            {
-              "column": "departure_time",
-              "modifications_count": 790,
-              "modifications_percentage": 75.4
-            },
-            {
-              "column": "stop_id",
-              "modifications_count": 12,
-              "modifications_percentage": 1.1
-            }
-          ]
-        }
-      },
-      {
-        "file_name": "stops.txt",
-        "status": "modified",
-        "columns_deleted_count": 1,
-        "rows_added_count": 2,
-        "rows_deleted_count": 1,
-        "rows_modified_count": 5,
-        "stats": {
-          "total_rows_base": 50,
-          "total_rows_new": 51,
-          "total_rows_modified": 5,
-          "rows_changed_percentage": 15.7,
-          "column_stats": [
-            {
-              "column": "stop_name",
-              "modifications_count": 3,
-              "modifications_percentage": 60.0
-            },
-            {
-              "column": "stop_lat",
-              "modifications_count": 2,
-              "modifications_percentage": 40.0
-            }
-          ]
-        }
-      },
+      { "file_name": "shapes.txt", "status": "added" },
+      { "file_name": "stop_times.txt", "status": "modified" },
+      { "file_name": "stops.txt", "status": "modified" },
       {
         "file_name": "trips.txt",
         "status": "not_compared"
@@ -117,7 +63,9 @@
       "stats": {
         "total_rows_base": 5000,
         "total_rows_new": 5075,
-        "total_rows_modified": 1048,
+        "rows_added_count": 120,
+        "rows_deleted_count": 45,
+        "rows_modified_count": 1048,
         "rows_changed_percentage": 23.9,
         "column_stats": [
           {
@@ -173,7 +121,10 @@
       "stats": {
         "total_rows_base": 50,
         "total_rows_new": 51,
-        "total_rows_modified": 5,
+        "columns_deleted_count": 1,
+        "rows_added_count": 2,
+        "rows_deleted_count": 1,
+        "rows_modified_count": 5,
         "rows_changed_percentage": 15.7,
         "column_stats": [
           {

--- a/spec/v2/json_schema/v2-rc1.json
+++ b/spec/v2/json_schema/v2-rc1.json
@@ -276,6 +276,11 @@
           "minimum": 0,
           "description": "Total number of rows in the new version of the file."
         },
+        "total_rows_modified": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of rows modified between the two versions of the file."
+        },
         "rows_changed_percentage": {
           "type": "number",
           "minimum": 0,

--- a/spec/v2/json_schema/v2-rc1.json
+++ b/spec/v2/json_schema/v2-rc1.json
@@ -129,31 +129,6 @@
           "type": "string",
           "enum": ["added", "deleted", "modified", "not_compared"],
           "description": "File-level status."
-        },
-        "columns_added_count": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Number of columns added."
-        },
-        "columns_deleted_count": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Number of columns deleted."
-        },
-        "rows_added_count": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "True count of rows added."
-        },
-        "rows_deleted_count": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "True count of rows deleted."
-        },
-        "rows_modified_count": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "True count of rows modified."
         }
       }
     },
@@ -275,10 +250,30 @@
           "minimum": 0,
           "description": "Total number of rows in the new version of the file."
         },
-        "total_rows_modified": {
+        "columns_added_count": {
           "type": "integer",
           "minimum": 0,
-          "description": "Total number of rows modified between the two versions of the file."
+          "description": "Number of columns added."
+        },
+        "columns_deleted_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of columns deleted."
+        },
+        "rows_added_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "True count of rows added."
+        },
+        "rows_deleted_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "True count of rows deleted."
+        },
+        "rows_modified_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "True count of rows modified."
         },
         "rows_changed_percentage": {
           "type": "number",

--- a/spec/v2/json_schema/v2-rc1.json
+++ b/spec/v2/json_schema/v2-rc1.json
@@ -1,16 +1,14 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/MobilityData/gtfs_diff/spec/v2/json_schema/gtfs_diff_v2_schema.json",
+  "$id": "https://github.com/MobilityData/gtfs_diff/spec/v2/json_schema/v2-rc1.json",
   "title": "GTFS Diff v2",
   "description": "Schema for GTFS Diff v2 output: a single JSON document describing all differences between two GTFS archives.",
   "type": "object",
   "required": ["metadata", "summary", "file_diffs"],
-  "additionalProperties": false,
   "properties": {
     "metadata": {
       "type": "object",
       "required": ["schema_version", "generated_at", "row_changes_cap_per_file", "base_feed", "new_feed", "unsupported_files"],
-      "additionalProperties": false,
       "properties": {
         "schema_version": {
           "type": "string",
@@ -33,7 +31,6 @@
           "items": {
             "type": "object",
             "required": ["file_name", "present_in"],
-            "additionalProperties": false,
             "properties": {
               "file_name": {
                 "type": "string",
@@ -51,8 +48,7 @@
     },
     "summary": {
       "type": "object",
-      "required": ["total_changes", "files_added_count", "files_deleted_count", "files_modified_count", "files"],
-      "additionalProperties": false,
+      "required": ["total_changes", "files_added_count", "files_deleted_count", "files_modified_count", "files_not_compared_count", "files"],
       "properties": {
         "total_changes": {
           "type": "integer",
@@ -74,6 +70,11 @@
           "minimum": 0,
           "description": "Number of files modified."
         },
+        "files_not_compared_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of files that could not be meaningfully compared."
+        },
         "files": {
           "type": "array",
           "items": { "$ref": "#/$defs/file_summary" }
@@ -89,7 +90,6 @@
     "column_entry": {
       "type": "object",
       "required": ["name", "position"],
-      "additionalProperties": false,
       "properties": {
         "name": {
           "type": "string",
@@ -105,7 +105,6 @@
     "feed_source": {
       "type": "object",
       "required": ["source", "downloaded_at"],
-      "additionalProperties": false,
       "properties": {
         "source": {
           "type": "string",
@@ -121,7 +120,6 @@
     "file_summary": {
       "type": "object",
       "required": ["file_name", "status"],
-      "additionalProperties": false,
       "properties": {
         "file_name": {
           "type": "string",
@@ -129,7 +127,7 @@
         },
         "status": {
           "type": "string",
-          "enum": ["added", "deleted", "modified"],
+          "enum": ["added", "deleted", "modified", "not_compared"],
           "description": "File-level status."
         },
         "columns_added_count": {
@@ -156,13 +154,13 @@
           "type": "integer",
           "minimum": 0,
           "description": "True count of rows modified."
-        }
+        },
+        "stats": { "$ref": "#/$defs/file_stats" }
       }
     },
     "file_diff": {
       "type": "object",
-      "required": ["file_name", "file_action", "columns_added", "columns_deleted"],
-      "additionalProperties": false,
+      "required": ["file_name", "file_action"],
       "properties": {
         "file_name": {
           "type": "string",
@@ -170,8 +168,14 @@
         },
         "file_action": {
           "type": "string",
-          "enum": ["modified", "added", "deleted"],
+          "enum": ["modified", "added", "deleted", "not_compared"],
           "description": "Action describing how this file changed."
+        },
+        "not_compared_reason": { "$ref": "#/$defs/not_compared_reason" },
+        "ignored_columns": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ignored_column" },
+          "description": "Columns excluded from the diff because their values are unreliable (e.g. they reference a file that was not compared)."
         },
         "columns_added": {
           "type": "array",
@@ -186,7 +190,6 @@
         "row_changes": {
           "type": "object",
           "required": ["primary_key", "columns", "added", "deleted", "modified"],
-          "additionalProperties": false,
           "properties": {
             "primary_key": {
               "type": "array",
@@ -219,7 +222,6 @@
         "truncated": {
           "type": "object",
           "required": ["is_truncated", "omitted_count"],
-          "additionalProperties": false,
           "properties": {
             "is_truncated": {
               "type": "boolean",
@@ -232,13 +234,85 @@
               "description": "Number of row changes omitted due to the cap."
             }
           }
+        },
+        "stats": { "$ref": "#/$defs/file_stats" }
+      }
+    },
+    "not_compared_reason": {
+      "type": "object",
+      "required": ["code", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Machine-readable reason code (e.g. \"id_churn\", \"missing_primary_key\", \"file_too_large\")."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable explanation of why the file was not compared."
+        }
+      }
+    },
+    "ignored_column": {
+      "type": "object",
+      "required": ["column", "reason"],
+      "properties": {
+        "column": {
+          "type": "string",
+          "description": "The column name that was ignored."
+        },
+        "reason": { "$ref": "#/$defs/not_compared_reason" }
+      }
+    },
+    "file_stats": {
+      "type": "object",
+      "properties": {
+        "total_rows_base": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of rows in the base version of the file."
+        },
+        "total_rows_new": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of rows in the new version of the file."
+        },
+        "rows_changed_percentage": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Percentage of rows that were added, deleted, or modified relative to the larger of the two versions."
+        },
+        "column_stats": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/column_stat" },
+          "description": "Per-column modification statistics. Only covers modified rows."
+        }
+      }
+    },
+    "column_stat": {
+      "type": "object",
+      "required": ["column", "modifications_count", "modifications_percentage"],
+      "properties": {
+        "column": {
+          "type": "string",
+          "description": "The column name."
+        },
+        "modifications_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of modified rows that had a change in this column."
+        },
+        "modifications_percentage": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "modifications_count as a percentage of total modified rows."
         }
       }
     },
     "row_added": {
       "type": "object",
       "required": ["identifier", "raw_value", "new_line_number"],
-      "additionalProperties": false,
       "properties": {
         "identifier": {
           "type": "object",
@@ -259,7 +333,6 @@
     "row_deleted": {
       "type": "object",
       "required": ["identifier", "raw_value", "base_line_number"],
-      "additionalProperties": false,
       "properties": {
         "identifier": {
           "type": "object",
@@ -280,7 +353,6 @@
     "row_modified": {
       "type": "object",
       "required": ["identifier", "raw_value", "base_line_number", "new_line_number", "field_changes"],
-      "additionalProperties": false,
       "properties": {
         "identifier": {
           "type": "object",
@@ -307,7 +379,6 @@
           "items": {
             "type": "object",
             "required": ["field", "base_value", "new_value"],
-            "additionalProperties": false,
             "properties": {
               "field": {
                 "type": "string",

--- a/spec/v2/json_schema/v2-rc1.json
+++ b/spec/v2/json_schema/v2-rc1.json
@@ -222,7 +222,7 @@
         },
         "message": {
           "type": "string",
-          "description": "Human-readable explanation of why the file was not compared."
+          "description": "Human-readable explanation of why the file or column was not compared."
         }
       }
     },

--- a/spec/v2/json_schema/v2-rc1.json
+++ b/spec/v2/json_schema/v2-rc1.json
@@ -154,8 +154,7 @@
           "type": "integer",
           "minimum": 0,
           "description": "True count of rows modified."
-        },
-        "stats": { "$ref": "#/$defs/file_stats" }
+        }
       }
     },
     "file_diff": {

--- a/spec/v2/specification.md
+++ b/spec/v2/specification.md
@@ -27,7 +27,7 @@ GtfsDiffOutput
 │   └── unsupported_files[]     # files skipped by the diff engine
 ├── summary                     # true aggregate counts (drives file tree sidebar)
 │   ├── files_not_compared_count
-│   └── files[]                 # per-file: name + true counts by action + stats
+│   └── files[]                 # per-file: name + true counts by action
 └── file_diffs[]                # one entry per changed supported file
     ├── file_name
     ├── file_action             # "added" | "deleted" | "modified" | "not_compared"
@@ -89,15 +89,6 @@ GtfsDiffOutput
 | `files[].rows_added` | Integer | Optional | True count of rows added. Present when > 0. |
 | `files[].rows_deleted` | Integer | Optional | True count of rows deleted. Present when > 0. |
 | `files[].rows_modified` | Integer | Optional | True count of rows modified. Present when > 0. |
-| `files[].stats` | Object | Optional | Statistical information about changes in this file. |
-| `files[].stats.total_rows_base` | Integer | Optional | Total number of rows in the base version of the file. |
-| `files[].stats.total_rows_new` | Integer | Optional | Total number of rows in the new version of the file. |
-| `files[].stats.total_rows_modified` | Integer | Optional | Total number of rows modified between the two versions of the file. |
-| `files[].stats.rows_changed_percentage` | Number | Optional | Percentage of rows that were added, deleted, or modified relative to the larger of the two versions. |
-| `files[].stats.column_stats` | Array | Optional | Per-column modification statistics. Only covers modified rows. |
-| `files[].stats.column_stats[].column` | String | Required | The column name. |
-| `files[].stats.column_stats[].modifications_count` | Integer | Required | Number of modified rows that had a change in this column. |
-| `files[].stats.column_stats[].modifications_percentage` | Number | Required | `modifications_count` as a percentage of total modified rows. |
 
 ### `file_diffs[]`
 

--- a/spec/v2/specification.md
+++ b/spec/v2/specification.md
@@ -80,7 +80,7 @@ GtfsDiffOutput
 | `files_added` | Integer | Required | Number of files added. |
 | `files_deleted` | Integer | Required | Number of files deleted. |
 | `files_modified` | Integer | Required | Number of files modified. |
-| `files_not_compared` | Integer | Required | Number of files that could not be meaningfully compared. |
+| `files_not_compared_count` | Integer | Required | Number of files that could not be meaningfully compared. |
 | `files` | Array | Required | Per-file summary with true (uncapped) counts. |
 | `files[].file_name` | String | Required | Name of the GTFS file. |
 | `files[].status` | String. Enum: `added`, `deleted`, `modified`, `not_compared` | Required | The file-level status. |

--- a/spec/v2/specification.md
+++ b/spec/v2/specification.md
@@ -27,7 +27,7 @@ GtfsDiffOutput
 │   └── unsupported_files[]     # files skipped by the diff engine
 ├── summary                     # true aggregate counts (drives file tree sidebar)
 │   ├── files_not_compared_count
-│   └── files[]                 # per-file: name + true counts by action
+│   └── files[]                 # per-file: name + status
 └── file_diffs[]                # one entry per changed supported file
     ├── file_name
     ├── file_action             # "added" | "deleted" | "modified" | "not_compared"
@@ -84,11 +84,25 @@ GtfsDiffOutput
 | `files` | Array | Required | Per-file summary with true (uncapped) counts. |
 | `files[].file_name` | String | Required | Name of the GTFS file. |
 | `files[].status` | String. Enum: `added`, `deleted`, `modified`, `not_compared` | Required | The file-level status. |
-| `files[].columns_added` | Integer | Optional | Number of columns added. Present when > 0. |
-| `files[].columns_deleted` | Integer | Optional | Number of columns deleted. Present when > 0. |
-| `files[].rows_added` | Integer | Optional | True count of rows added. Present when > 0. |
-| `files[].rows_deleted` | Integer | Optional | True count of rows deleted. Present when > 0. |
-| `files[].rows_modified` | Integer | Optional | True count of rows modified. Present when > 0. |
+
+### `stats`
+
+The `stats` object appears in `file_diffs[]`. All fields are optional.
+
+| Field | Type | Description |
+|:------|:-----|:------------|
+| `total_rows_base` | Integer | Total number of rows in the base version of the file. |
+| `total_rows_new` | Integer | Total number of rows in the new version of the file. |
+| `columns_added_count` | Integer | Number of columns added. |
+| `columns_deleted_count` | Integer | Number of columns deleted. |
+| `rows_added_count` | Integer | True count of rows added. |
+| `rows_deleted_count` | Integer | True count of rows deleted. |
+| `rows_modified_count` | Integer | True count of rows modified. |
+| `rows_changed_percentage` | Number | Percentage of rows that were added, deleted, or modified relative to the larger of the two versions. |
+| `column_stats` | Array | Per-column modification statistics. Only covers modified rows. |
+| `column_stats[].column` | String | The column name. |
+| `column_stats[].modifications_count` | Integer | Number of modified rows that had a change in this column. |
+| `column_stats[].modifications_percentage` | Number | `modifications_count` as a percentage of total modified rows. |
 
 ### `file_diffs[]`
 
@@ -117,7 +131,7 @@ Each entry represents one changed supported file.
 | `truncated` | Object | Optional | Present only when row changes exceed the cap. |
 | `truncated.is_truncated` | Boolean | Required | Always `true` when present. |
 | `truncated.omitted_count` | Integer | Required | Number of row changes omitted due to the cap. |
-| `stats` | Object | Optional | Statistical information about changes in this file. See `files[].stats` in `summary` for field definitions. |
+| `stats` | Object | Optional | Statistics for this file. See `stats` section above. |
 
 ## Capping behavior
 

--- a/spec/v2/specification.md
+++ b/spec/v2/specification.md
@@ -26,10 +26,17 @@ GtfsDiffOutput
 │   ├── new_feed                # source (URL or local path), downloaded_at
 │   └── unsupported_files[]     # files skipped by the diff engine
 ├── summary                     # true aggregate counts (drives file tree sidebar)
-│   └── files[]                 # per-file: name + true counts by action
+│   ├── files_not_compared_count
+│   └── files[]                 # per-file: name + true counts by action + stats
 └── file_diffs[]                # one entry per changed supported file
     ├── file_name
-    ├── file_action             # "added" | "deleted" | "modified"
+    ├── file_action             # "added" | "deleted" | "modified" | "not_compared"
+    ├── not_compared_reason     # present when file_action is "not_compared"
+    │   ├── code
+    │   └── message
+    ├── ignored_columns[]       # columns excluded from the diff
+    │   ├── column
+    │   └── reason              # reuses not_compared_reason structure
     ├── columns_added[]
     ├── columns_deleted[]
     ├── row_changes
@@ -38,7 +45,12 @@ GtfsDiffOutput
     │   ├── added[]             # capped
     │   ├── deleted[]           # capped
     │   └── modified[]          # capped
-    └── truncated               # cap metadata (omitted counts)
+    ├── truncated               # cap metadata (omitted counts)
+    └── stats                   # optional file-level & column-level statistics
+        ├── total_rows_base
+        ├── total_rows_new
+        ├── rows_changed_percentage
+        └── column_stats[]
 ```
 
 ## Fields description
@@ -68,14 +80,23 @@ GtfsDiffOutput
 | `files_added` | Integer | Required | Number of files added. |
 | `files_deleted` | Integer | Required | Number of files deleted. |
 | `files_modified` | Integer | Required | Number of files modified. |
+| `files_not_compared` | Integer | Required | Number of files that could not be meaningfully compared. |
 | `files` | Array | Required | Per-file summary with true (uncapped) counts. |
 | `files[].file_name` | String | Required | Name of the GTFS file. |
-| `files[].status` | String. Enum: `added`, `deleted`, `modified` | Required | The file-level status. |
+| `files[].status` | String. Enum: `added`, `deleted`, `modified`, `not_compared` | Required | The file-level status. |
 | `files[].columns_added` | Integer | Optional | Number of columns added. Present when > 0. |
 | `files[].columns_deleted` | Integer | Optional | Number of columns deleted. Present when > 0. |
 | `files[].rows_added` | Integer | Optional | True count of rows added. Present when > 0. |
 | `files[].rows_deleted` | Integer | Optional | True count of rows deleted. Present when > 0. |
 | `files[].rows_modified` | Integer | Optional | True count of rows modified. Present when > 0. |
+| `files[].stats` | Object | Optional | Statistical information about changes in this file. |
+| `files[].stats.total_rows_base` | Integer | Optional | Total number of rows in the base version of the file. |
+| `files[].stats.total_rows_new` | Integer | Optional | Total number of rows in the new version of the file. |
+| `files[].stats.rows_changed_percentage` | Number | Optional | Percentage of rows that were added, deleted, or modified relative to the larger of the two versions. |
+| `files[].stats.column_stats` | Array | Optional | Per-column modification statistics. Only covers modified rows. |
+| `files[].stats.column_stats[].column` | String | Required | The column name. |
+| `files[].stats.column_stats[].modifications_count` | Integer | Required | Number of modified rows that had a change in this column. |
+| `files[].stats.column_stats[].modifications_percentage` | Number | Required | `modifications_count` as a percentage of total modified rows. |
 
 ### `file_diffs[]`
 
@@ -84,7 +105,15 @@ Each entry represents one changed supported file.
 | Field | Type | Required | Description |
 |:------|:-----|:---------|:------------|
 | `file_name` | String | Required | Name of the GTFS file. |
-| `file_action` | String. Enum: `"added"`, `"deleted"`, `"modified"` | Required | How this file changed between the two archives. |
+| `file_action` | String. Enum: `"added"`, `"deleted"`, `"modified"`, `"not_compared"` | Required | How this file changed between the two archives. |
+| `not_compared_reason` | Object | Optional | Present when `file_action` is `"not_compared"`. Explains why the file was not compared. |
+| `not_compared_reason.code` | String | Required | Machine-readable reason code (e.g. `"id_churn"`, `"missing_primary_key"`, `"file_too_large"`). |
+| `not_compared_reason.message` | String | Required | Human-readable explanation of why the file was not compared. |
+| `ignored_columns` | Array | Optional | Columns excluded from the diff because their values are unreliable (e.g. they reference a file that was not compared). |
+| `ignored_columns[].column` | String | Required | The column name that was ignored. |
+| `ignored_columns[].reason` | Object | Required | Why the column was ignored. Same structure as `not_compared_reason`. |
+| `ignored_columns[].reason.code` | String | Required | Machine-readable reason code. |
+| `ignored_columns[].reason.message` | String | Required | Human-readable explanation. |
 | `columns_added` | Array of String | Required | List of column names added to this file. |
 | `columns_deleted` | Array of String | Required | List of column names deleted from this file. |
 | `row_changes` | Object | Conditionally required | Present when the file has row-level changes (i.e. `file_action` is `"modified"`). |
@@ -96,6 +125,7 @@ Each entry represents one changed supported file.
 | `truncated` | Object | Optional | Present only when row changes exceed the cap. |
 | `truncated.is_truncated` | Boolean | Required | Always `true` when present. |
 | `truncated.omitted_count` | Integer | Required | Number of row changes omitted due to the cap. |
+| `stats` | Object | Optional | Statistical information about changes in this file. See `files[].stats` in `summary` for field definitions. |
 
 ## Capping behavior
 
@@ -115,7 +145,7 @@ This keeps the diff focused on what was actually compared, while still surfacing
 
 ## JSON Schema
 
-A formal JSON Schema for validation is available at [`json_schema/gtfs_diff_v2_schema.json`](json_schema/gtfs_diff_v2_schema.json).
+A formal JSON Schema for validation is available at [`json_schema/v2-rc1.schema.json`](json_schema/v2-rc1.json).
 
 ## Example
 
@@ -127,6 +157,7 @@ Given two GTFS archives where:
 - `shapes.txt` was added as a new file
 - `stop_times.txt` had 1213 row changes (120 added, 45 deleted, 1048 modified)
 - `stops.txt` had a column deleted and 8 row changes (2 added, 1 deleted, 5 modified)
+- `trips.txt` could not be meaningfully compared due to ID churn
 - `readme.pdf` and `custom_notes.txt` are non-GTFS files present in the archives
 
 The v2 output will:
@@ -135,6 +166,8 @@ The v2 output will:
 - Cap `stop_times.txt` row details to 50, reporting `omitted_count: 1163`
 - Show all 8 `stops.txt` row changes (under the cap, no `truncated` field)
 - Show `shapes.txt` as a file-level addition with no `row_changes`
+- Show `trips.txt` with `file_action: "not_compared"` and a `not_compared_reason` explaining the ID churn
+- Include optional `stats` on modified files with row counts, change percentages, and per-column modification breakdowns
 
 ## Full example
 

--- a/spec/v2/specification.md
+++ b/spec/v2/specification.md
@@ -146,7 +146,7 @@ This keeps the diff focused on what was actually compared, while still surfacing
 
 ## JSON Schema
 
-A formal JSON Schema for validation is available at [`json_schema/v2-rc1.schema.json`](json_schema/v2-rc1.json).
+A formal JSON Schema for validation is available at [`json_schema/v2-rc1.json`](json_schema/v2-rc1.json).
 
 ## Example
 

--- a/spec/v2/specification.md
+++ b/spec/v2/specification.md
@@ -9,7 +9,7 @@ A GTFS file is a ZIP archive containing a number of CSV files. A "GTFS Diff v2" 
 3. **Explicit scope**: files outside the supported scope are reported in `metadata.unsupported_files` rather than silently ignored.
 4. **Spec-aligned**: compatible with the existing [GTFS Diff v1 specification](../v1/specification.md).
 
-## Supported scope (v2.0)
+## Supported scope (v2.0.0-rc1)
 
 This version of the schema only supports files defined in the official [GTFS Schedule reference](https://gtfs.org/documentation/schedule/reference/).
 Any unsupported file in the GTFS archive (including non-`.txt` files like `readme.pdf`, `locations.geojson`, etc.) is **not diffed**. Instead, it is reported in `metadata.unsupported_files`.
@@ -92,6 +92,7 @@ GtfsDiffOutput
 | `files[].stats` | Object | Optional | Statistical information about changes in this file. |
 | `files[].stats.total_rows_base` | Integer | Optional | Total number of rows in the base version of the file. |
 | `files[].stats.total_rows_new` | Integer | Optional | Total number of rows in the new version of the file. |
+| `files[].stats.total_rows_modified` | Integer | Optional | Total number of rows modified between the two versions of the file. |
 | `files[].stats.rows_changed_percentage` | Number | Optional | Percentage of rows that were added, deleted, or modified relative to the larger of the two versions. |
 | `files[].stats.column_stats` | Array | Optional | Per-column modification statistics. Only covers modified rows. |
 | `files[].stats.column_stats[].column` | String | Required | The column name. |


### PR DESCRIPTION
### Summary:
- Changed schema version from 2.0.0 to 2.0.0-rc1 and rename schema file to v2-rc1.json
- Removed all `additionalProperties` constraints to support extensions
- Added `not_compared` file status with a reason object (`code` + `message`) for files that cannot be meaningfully compared
- Added `ignored_columns` to file diffs for columns excluded due to unreliable values (e.g. referencing a file that isn't compared)
- Add optional per-file and per-column change statistics (row counts, change percentages, column modification breakdowns)
- Add `files_not_compared_count` to the summary
- Add validation scripts and a GitHub Action to check JSON syntax and validate examples against the schema
